### PR TITLE
Fix missing JWT settings in mail_service

### DIFF
--- a/services/mail_service/app/config.py
+++ b/services/mail_service/app/config.py
@@ -6,6 +6,9 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     resend_api_key: str
     mail_from: str = "noreply@hobbyhosting.org"
+    # Secret and algorithm for verifying JWT tokens from auth_service
+    jwt_secret: str
+    jwt_algo: str = "HS256"
 
     class Config:
         env_file = ".env"  # laddas automatiskt av Pydantic


### PR DESCRIPTION
## Summary
- load JWT secret and algorithm in `mail_service` configuration

## Testing
- `ruff check services/mail_service/app/config.py --fix`
- `black services/mail_service/app/config.py`
- `isort services/mail_service/app/config.py`
