### PR TITLE
Add JWT config to mail service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# PostgreSQL
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+AUTH_DB=auth_db
+MAIL_DB=mail_db
+ECOM_DB=ecom_db
+
+# Mail service
+RESEND_API_KEY=
+MAIL_FROM=noreply@hobbyhosting.org
+JWT_SECRET=
+JWT_ALGO=HS256

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docker-compose.override.yml
 # ▶ Env & secrets
 .env
 .env.*
+!.env.example
 auth.token
 
 # ▶ Misc

--- a/docs/README2.md
+++ b/docs/README2.md
@@ -41,6 +41,19 @@ make health-auth
 
 ---
 
+## 🔑 Miljövariabler
+
+Exempel finns i `.env.example`.
+
+### Mail Service
+
+- `RESEND_API_KEY` – API-nyckel för utskick via Resend
+- `MAIL_FROM` – standardavsändare
+- `JWT_SECRET` – hemlighet för verifiering av tokens
+- `JWT_ALGO` – algoritm för signering (default HS256)
+
+---
+
 ## 🌐 Subdomäner
 
 | Subdomän                  | Beskrivning        |

--- a/services/mail_service/app/config.py
+++ b/services/mail_service/app/config.py
@@ -6,6 +6,8 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     resend_api_key: str
     mail_from: str = "noreply@hobbyhosting.org"
+    jwt_secret: str
+    jwt_algo: str = "HS256"
 
     class Config:
         env_file = ".env"  # laddas automatiskt av Pydantic


### PR DESCRIPTION
## Summary
- add `jwt_secret` and `jwt_algo` to mail service settings
- document environment variables
- provide `.env.example` and allow it through .gitignore

## Testing
- `pre-commit` *(fails: command not found)*