### PR TITLE
Add auth health test

### DIFF
--- a/docs/README2.md
+++ b/docs/README2.md
@@ -59,6 +59,18 @@ make health-auth
 
 ---
 
+## 🧪 Tester
+
+Kör alla enhetstester och frontendtester med:
+
+```bash
+make test
+```
+
+Det använder `pytest` för Python och `jest` för JavaScript.
+
+---
+
 ## 🧪 Testanvändare
 
 | Email                    | Lösenord     |

--- a/tests/test_auth_health.py
+++ b/tests/test_auth_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from auth_service.app.main import app
+
+client = TestClient(app)
+
+def test_auth_health():
+    response = client.get("/auth/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a basic test for `/auth/health` using FastAPI TestClient
- document how to run tests with `make test`

## Testing
- `python -m pytest -q tests/test_auth_health.py` *(fails: No module named pytest)*