### PR TITLE
Implement CRM todos

### DIFF
--- a/services/admin_sync_service/app/crm/__init__.py
+++ b/services/admin_sync_service/app/crm/__init__.py
@@ -1,0 +1,3 @@
+from . import models, schemas
+
+__all__ = ["models", "schemas"]

--- a/services/admin_sync_service/app/crm/models.py
+++ b/services/admin_sync_service/app/crm/models.py
@@ -1,0 +1,40 @@
+
+from app.dependencies import Base
+from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+
+
+class Company(Base):
+    __tablename__ = "companies"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    status = Column(String, default="active")
+    notes = Column(Text)
+
+    contacts = relationship("Contact", back_populates="company", cascade="all, delete-orphan")
+    todos = relationship("ToDo", back_populates="company", cascade="all, delete-orphan")
+
+
+class Contact(Base):
+    __tablename__ = "contacts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    company_id = Column(Integer, ForeignKey("companies.id"), nullable=False)
+    name = Column(String, nullable=False)
+    email = Column(String)
+    phone = Column(String)
+
+    company = relationship("Company", back_populates="contacts")
+
+
+class ToDo(Base):
+    __tablename__ = "todos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    company_id = Column(Integer, ForeignKey("companies.id"), nullable=False)
+    title = Column(String, nullable=False)
+    due_date = Column(Date, nullable=True)
+    completed = Column(Boolean, default=False)
+
+    company = relationship("Company", back_populates="todos")

--- a/services/admin_sync_service/app/crm/routes.py
+++ b/services/admin_sync_service/app/crm/routes.py
@@ -40,3 +40,50 @@ def get_company(company_id: int, db: Session = Depends(get_db)):
     if not company:
         raise HTTPException(status_code=404, detail="Company not found")
     return company
+
+
+@router.post("/companies/{company_id}/todos", response_model=schemas.ToDoOut)
+def create_todo(company_id: int, todo: schemas.ToDoCreate, db: Session = Depends(get_db)):
+    company = db.query(models.Company).filter(models.Company.id == company_id).first()
+    if not company:
+        raise HTTPException(status_code=404, detail="Company not found")
+    db_todo = models.ToDo(**todo.dict(), company_id=company_id)
+    db.add(db_todo)
+    db.commit()
+    db.refresh(db_todo)
+    return db_todo
+
+
+@router.get("/companies/{company_id}/todos", response_model=List[schemas.ToDoOut])
+def list_todos(company_id: int, db: Session = Depends(get_db)):
+    return db.query(models.ToDo).filter(models.ToDo.company_id == company_id).all()
+
+
+@router.get("/todos/{todo_id}", response_model=schemas.ToDoOut)
+def get_todo(todo_id: int, db: Session = Depends(get_db)):
+    todo = db.query(models.ToDo).filter(models.ToDo.id == todo_id).first()
+    if not todo:
+        raise HTTPException(status_code=404, detail="To-do not found")
+    return todo
+
+
+@router.put("/todos/{todo_id}", response_model=schemas.ToDoOut)
+def update_todo(todo_id: int, todo: schemas.ToDoCreate, db: Session = Depends(get_db)):
+    db_todo = db.query(models.ToDo).filter(models.ToDo.id == todo_id).first()
+    if not db_todo:
+        raise HTTPException(status_code=404, detail="To-do not found")
+    for key, value in todo.dict().items():
+        setattr(db_todo, key, value)
+    db.commit()
+    db.refresh(db_todo)
+    return db_todo
+
+
+@router.delete("/todos/{todo_id}", status_code=204)
+def delete_todo(todo_id: int, db: Session = Depends(get_db)):
+    db_todo = db.query(models.ToDo).filter(models.ToDo.id == todo_id).first()
+    if not db_todo:
+        raise HTTPException(status_code=404, detail="To-do not found")
+    db.delete(db_todo)
+    db.commit()
+    return None

--- a/services/admin_sync_service/app/crm/schemas.py
+++ b/services/admin_sync_service/app/crm/schemas.py
@@ -1,0 +1,57 @@
+from datetime import date
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class ContactBase(BaseModel):
+    name: str
+    email: Optional[str] = None
+    phone: Optional[str] = None
+
+
+class ContactCreate(ContactBase):
+    pass
+
+
+class ContactOut(ContactBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class ToDoBase(BaseModel):
+    title: str
+    due_date: Optional[date] = None
+    completed: bool = False
+
+
+class ToDoCreate(ToDoBase):
+    pass
+
+
+class ToDoOut(ToDoBase):
+    id: int
+
+    class Config:
+        from_attributes = True
+
+
+class CompanyBase(BaseModel):
+    name: str
+    status: str
+    notes: Optional[str] = None
+
+
+class CompanyCreate(CompanyBase):
+    contacts: List[ContactCreate] = []
+
+
+class CompanyOut(CompanyBase):
+    id: int
+    contacts: List[ContactOut] = []
+    todos: List[ToDoOut] = []
+
+    class Config:
+        from_attributes = True

--- a/tests/test_admin_sync_crm.py
+++ b/tests/test_admin_sync_crm.py
@@ -1,0 +1,35 @@
+import os
+from fastapi.testclient import TestClient
+
+# Ensure local sqlite DB for testing
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_sync.db")
+
+from admin_sync_service.app.main import app
+
+client = TestClient(app)
+
+
+def test_create_company_and_todo():
+    # Create a company
+    comp_resp = client.post(
+        "/crm/companies",
+        json={"name": "Acme", "status": "active", "notes": "", "contacts": []},
+    )
+    assert comp_resp.status_code == 200
+    company_id = comp_resp.json()["id"]
+
+    # Add todo
+    todo_resp = client.post(
+        f"/crm/companies/{company_id}/todos",
+        json={"title": "Call customer", "due_date": None, "completed": False},
+    )
+    assert todo_resp.status_code == 200
+    todo_data = todo_resp.json()
+    assert todo_data["title"] == "Call customer"
+
+    # List todos
+    list_resp = client.get(f"/crm/companies/{company_id}/todos")
+    assert list_resp.status_code == 200
+    todos = list_resp.json()
+    assert len(todos) == 1
+    assert todos[0]["id"] == todo_data["id"]


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for CRM with Company, Contact and ToDo
- add pydantic schemas and CRUD endpoints to manage todos
- basic test for creating a todo

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*