### PR TITLE
Add admin dashboard skeleton

### DIFF
--- a/apps/admin-dashboard/README.md
+++ b/apps/admin-dashboard/README.md
@@ -1,0 +1,13 @@
+# HobbyHosting Admin Frontend
+
+This Next.js project serves as a starting point for the admin dashboard.
+
+## Development
+
+```bash
+cd apps/admin-dashboard
+npm install
+npm run dev
+```
+
+The UI components are imported from `packages/ui`.

--- a/apps/admin-dashboard/next-env.d.ts
+++ b/apps/admin-dashboard/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/apps/admin-dashboard/next.config.js
+++ b/apps/admin-dashboard/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/apps/admin-dashboard/package.json
+++ b/apps/admin-dashboard/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hobbyhosting-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "tailwindcss": "^3.4.3",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/apps/admin-dashboard/postcss.config.js
+++ b/apps/admin-dashboard/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/admin-dashboard/src/pages/_app.tsx
+++ b/apps/admin-dashboard/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import "../styles/globals.css";
+import type { AppProps } from "next/app";
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/apps/admin-dashboard/src/pages/api/health.ts
+++ b/apps/admin-dashboard/src/pages/api/health.ts
@@ -1,0 +1,8 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<{ status: string }>,
+) {
+  res.status(200).json({ status: "ok" });
+}

--- a/apps/admin-dashboard/src/pages/dashboard.tsx
+++ b/apps/admin-dashboard/src/pages/dashboard.tsx
@@ -1,0 +1,16 @@
+import Head from "next/head";
+import { Button } from "../../../packages/ui/src";
+
+export default function Dashboard() {
+  return (
+    <>
+      <Head>
+        <title>Dashboard</title>
+      </Head>
+      <main className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+        <Button>Example Button</Button>
+      </main>
+    </>
+  );
+}

--- a/apps/admin-dashboard/src/pages/index.tsx
+++ b/apps/admin-dashboard/src/pages/index.tsx
@@ -1,0 +1,18 @@
+import Head from "next/head";
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>HobbyHosting Admin</title>
+      </Head>
+      <main className="p-4">
+        <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+        <Link href="/dashboard" className="text-blue-600 underline">
+          Go to Dashboard
+        </Link>
+      </main>
+    </>
+  );
+}

--- a/apps/admin-dashboard/src/styles/globals.css
+++ b/apps/admin-dashboard/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/admin-dashboard/tailwind.config.js
+++ b/apps/admin-dashboard/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/admin-dashboard/tsconfig.json
+++ b/apps/admin-dashboard/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@hobbyhosting/ui": ["../../packages/ui/src"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docs/README2.md
+++ b/docs/README2.md
@@ -10,6 +10,8 @@ Ett modernt DevOps-baserat plattformsprojekt byggt med microservices, Docker, Fa
 hobbyhosting/
 ├── apps/                  # Fristående appar (frontend/adminjs etc)
 │   └── hobbyhosting-frontend/
+├── packages/
+│   └── ui/                # Återanvändbara React-komponenter
 ├── services/              # Backend-tjänster
 │   ├── auth_service/
 │   ├── mail_service/
@@ -71,6 +73,29 @@ Exempel finns i `.env.example`.
 - Allt byggs och körs genom `config/docker-compose.yml`
 - Caddy hanterar HTTPS + domäner automatiskt
 - Alla tjänster körs via interna nätverk (`backend`)
+
+---
+
+## 🎨 Frontend & UI
+
+Det finns ett separat paket `packages/ui` som innehåller återanvändbara
+React-komponenter. Installera beroenden och bygg paketet via:
+
+```bash
+cd packages/ui
+npm install
+npm run build
+```
+
+Dessa komponenter kan sedan importeras i admin-frontenden för en enhetlig
+design.
+Adminpanelen ligger under `apps/hobbyhosting-frontend` och startas med:
+
+```bash
+cd apps/hobbyhosting-frontend
+npm install
+npm run dev
+```
 
 ---
 
@@ -142,7 +167,9 @@ vanligtvis en 404- eller proxy-felkod.
 - Lägga till CI/CD
 - Integrera mailutskick
 - Lägg till docs för hur auth fungerar
+- Bygg vidare på `packages/ui` för delad design
+- Skapa admin-dashboard i Next.js under `apps/hobbyhosting-frontend`
 
 ---
 
-> Senast uppdaterad: 4 maj 2025
+> Senast uppdaterad: 17 maj 2025

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "private": true,
   "devDependencies": {
     "eslint": "^8.57.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "typescript": "^5.3.3",
+    "tailwindcss": "^3.4.3",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.1.0"
   }
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,13 @@
+# @hobbyhosting/ui
+
+Reusable React components for the HobbyHosting admin dashboard.
+
+```
+npm install @hobbyhosting/ui
+```
+
+Currently includes:
+
+- `Button` – primary action button
+- `Card` – simple white container with shadow
+- `Navbar` – basic horizontal navigation bar

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hobbyhosting/ui",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export interface ButtonProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Button: React.FC<ButtonProps> = ({ children, className = "" }) => {
+  return (
+    <button
+      className={`px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 ${className}`.trim()}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+export interface CardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Card: React.FC<CardProps> = ({ children, className = "" }) => (
+  <div className={`p-4 rounded shadow bg-white ${className}`.trim()}>
+    {children}
+  </div>
+);

--- a/packages/ui/src/components/Navbar.tsx
+++ b/packages/ui/src/components/Navbar.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import Link from "next/link";
+
+export interface NavItem {
+  href: string;
+  label: string;
+}
+
+export interface NavbarProps {
+  items: NavItem[];
+  className?: string;
+}
+
+export const Navbar: React.FC<NavbarProps> = ({ items, className = "" }) => (
+  <nav className={`bg-gray-800 text-white p-4 ${className}`.trim()}>
+    <ul className="flex space-x-4">
+      {items.map((item) => (
+        <li key={item.href}>
+          <Link href={item.href}>{item.label}</Link>
+        </li>
+      ))}
+    </ul>
+  </nav>
+);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./components/Button";
+export * from "./components/Card";
+export * from "./components/Navbar";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "jsx": "react",
+    "declaration": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create `apps/admin-dashboard` with basic Next.js setup
- add `Card` and `Navbar` components to shared `ui` package
- document running the admin dashboard and new UI components
- update project TODO list

## Testing
- `make format` *(succeeds but reformats some files)*
- `make lint` *(passes: JS/TS skipped, Ruff ok)*
- `make test` *(fails: `pytest` not found)*