### PR TITLE
Add environment setup helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
         migrate seed-db backup-db \
         tag-release docker-push deploy \
         run-auth run-admin-fe run-ecom-fe \
-        clean-all
+        clean-all setup-env
 
 ## 📚 Hjälp: visa tillgängliga make-kommandon
 help:
@@ -168,6 +168,9 @@ run-admin-fe:
 
 run-ecom-fe:
 	cd services/ecom/frontend && yarn dev --port 3000
+setup-env:
+	./scripts/setup_env.sh
+
 
 # ─── Housekeeping ─────────────────────────────────────────────
 

--- a/docs/README2.md
+++ b/docs/README2.md
@@ -46,6 +46,7 @@ make health-auth
 ## 🔑 Miljövariabler
 
 Exempel finns i `.env.example`.
+Development and production configs are generated with `./scripts/setup_env.sh`, creating `.env.dev` and `.env.prod`.
 
 ### Mail Service
 

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Set up development and production env files if missing
+# Usage: ./scripts/setup_env.sh [--force]
+
+set -euo pipefail
+
+force=0
+if [[ "${1:-}" == "--force" ]]; then
+  force=1
+fi
+
+for target in .env.dev .env.prod; do
+  if [[ $force -eq 1 || ! -f "$target" ]]; then
+    if [[ -f .env.example ]]; then
+      cp .env.example "$target"
+    else
+      cat > "$target" <<'FEOF'
+# POSTGRES_USER=
+# POSTGRES_PASSWORD=
+# AUTH_DB=
+# MAIL_DB=
+# ECOM_DB=
+# RESEND_API_KEY=
+# MAIL_FROM=
+# JWT_SECRET=
+# JWT_ALGO=HS256
+FEOF
+    fi
+    echo "Created $target"
+  fi
+done


### PR DESCRIPTION
## Summary
- add a `setup-env` Makefile target
- create `scripts/setup_env.sh` for generating `.env.dev` and `.env.prod`
- mention the new script in the docs

## Testing
- `make lint`
- `make test` *(fails: No module named pytest)*