### PR TITLE
Add admin chat feature

### DIFF
--- a/packages/ui/src/components/Chat.tsx
+++ b/packages/ui/src/components/Chat.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+
+interface Message {
+  id: number;
+  username: string;
+  message: string;
+  created_at: string;
+}
+
+export interface ChatProps {
+  apiUrl: string;
+  token: string;
+}
+
+export const Chat: React.FC<ChatProps> = ({ apiUrl, token }) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    fetch(`${apiUrl}/chat/messages`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then(setMessages)
+      .catch(console.error);
+  }, [apiUrl, token]);
+
+  const sendMessage = async () => {
+    if (!input) return;
+    const resp = await fetch(`${apiUrl}/chat/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ message: input }),
+    });
+    if (resp.ok) {
+      const msg = await resp.json();
+      setMessages((prev) => [...prev, msg]);
+      setInput("");
+    }
+  };
+
+  return (
+    <div className="border rounded p-2">
+      <div className="h-48 overflow-y-auto mb-2">
+        {messages.map((m) => (
+          <div key={m.id}>
+            <strong>{m.username}:</strong> {m.message}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border px-2 py-1 rounded"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          onClick={sendMessage}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./components/Button";
+export * from "./components/Chat";

--- a/services/admin_sync_service/app/chat/models.py
+++ b/services/admin_sync_service/app/chat/models.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from admin_sync_service.app.dependencies import Base
+from sqlalchemy import Column, DateTime, Integer, String
+
+
+class ChatMessage(Base):
+    __tablename__ = "chat_messages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, nullable=False)
+    message = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/services/admin_sync_service/app/chat/schemas.py
+++ b/services/admin_sync_service/app/chat/schemas.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class ChatMessageCreate(BaseModel):
+    message: str
+
+
+class ChatMessageOut(ChatMessageCreate):
+    id: int
+    username: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/tests/test_admin_chat.py
+++ b/tests/test_admin_chat.py
@@ -1,0 +1,34 @@
+import os
+from jose import jwt
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_sync.db")
+
+from admin_sync_service.app.main import app
+
+client = TestClient(app)
+SECRET = "supersecret"
+
+
+def make_token():
+    return jwt.encode({"sub": "admin@hobbyhosting.org", "is_admin": True}, SECRET, algorithm="HS256")
+
+
+def test_chat_message_create_and_list():
+    token = make_token()
+    resp = client.post(
+        "/chat/messages",
+        json={"message": "Hello"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["message"] == "Hello"
+    assert data["username"] == "admin@hobbyhosting.org"
+
+    list_resp = client.get(
+        "/chat/messages", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert list_resp.status_code == 200
+    msgs = list_resp.json()
+    assert any(m["message"] == "Hello" for m in msgs)


### PR DESCRIPTION
## Summary
- implement ChatMessage model and schema
- expose admin chat API endpoints
- create reusable Chat React component
- add basic API test for chat routes
- include empty __init__ for chat package

## Testing
- `make lint`
- `make test` *(fails: No module named pytest)*