### PR TITLE
Add admin frontend skeleton and UI components

### DIFF
--- a/apps/hobbyhosting-frontend/README.md
+++ b/apps/hobbyhosting-frontend/README.md
@@ -1,0 +1,13 @@
+# HobbyHosting Admin Frontend
+
+This is a simple Next.js dashboard for administrating HobbyHosting.
+
+## Development
+
+```bash
+cd apps/hobbyhosting-frontend
+npm install
+npm run dev
+```
+
+The app listens on http://localhost:8080 via docker-compose.

--- a/apps/hobbyhosting-frontend/next-env.d.ts
+++ b/apps/hobbyhosting-frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/hobbyhosting-frontend/package.json
+++ b/apps/hobbyhosting-frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hobbyhosting-frontend",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@hobbyhosting/ui": "file:../../packages/ui"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/apps/hobbyhosting-frontend/src/pages/_app.tsx
+++ b/apps/hobbyhosting-frontend/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from "next/app";
+import "../styles/globals.css";
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/apps/hobbyhosting-frontend/src/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/src/pages/index.tsx
@@ -1,0 +1,10 @@
+import { Button } from "@hobbyhosting/ui";
+
+export default function Home() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+      <Button>Click me</Button>
+    </main>
+  );
+}

--- a/apps/hobbyhosting-frontend/src/styles/globals.css
+++ b/apps/hobbyhosting-frontend/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/hobbyhosting-frontend/tailwind.config.js
+++ b/apps/hobbyhosting-frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/apps/hobbyhosting-frontend/tsconfig.json
+++ b/apps/hobbyhosting-frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docs/README2.md
+++ b/docs/README2.md
@@ -10,6 +10,8 @@ Ett modernt DevOps-baserat plattformsprojekt byggt med microservices, Docker, Fa
 hobbyhosting/
 ├── apps/                  # Fristående appar (frontend/adminjs etc)
 │   └── hobbyhosting-frontend/
+├── packages/
+│   └── ui/                # Återanvändbara React-komponenter
 ├── services/              # Backend-tjänster
 │   ├── auth_service/
 │   ├── mail_service/
@@ -71,6 +73,38 @@ Exempel finns i `.env.example`.
 - Allt byggs och körs genom `config/docker-compose.yml`
 - Caddy hanterar HTTPS + domäner automatiskt
 - Alla tjänster körs via interna nätverk (`backend`)
+
+---
+
+## 🎨 Frontend & UI
+
+Det finns ett separat paket `packages/ui` som innehåller återanvändbara
+React-komponenter. Installera beroenden och bygg paketet via:
+
+```bash
+cd packages/ui
+npm install
+npm run build
+```
+
+Dessa komponenter kan sedan importeras i admin-frontenden för en enhetlig
+design.
+
+Exempel på komponenter som finns i dagsläget:
+
+- `Button`
+- `Card`
+- `Navbar`
+
+### Starta admin-dashboard lokalt
+
+```bash
+cd apps/hobbyhosting-frontend
+npm install
+npm run dev
+```
+
+Applikationen körs då på http://localhost:8080 via Caddy.
 
 ---
 
@@ -138,10 +172,12 @@ vanligtvis en 404- eller proxy-felkod.
 
 ## 🛠 TODO (för vidare utveckling)
 
+- Skapa Next.js-admin-dashboard under `apps/hobbyhosting-frontend`
 - Rensa upp gammal kod i hobbyhosting-frontend
 - Lägga till CI/CD
 - Integrera mailutskick
 - Lägg till docs för hur auth fungerar
+- Bygg vidare på `packages/ui` för delad design
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "private": true,
   "devDependencies": {
     "eslint": "^8.57.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "typescript": "^5.3.3",
+    "tailwindcss": "^3.4.3",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.1.0"
   }
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,13 @@
+# @hobbyhosting/ui
+
+Reusable React components for the HobbyHosting admin dashboard.
+
+```bash
+npm install @hobbyhosting/ui
+```
+
+Currently provides:
+
+- `Button` – basic styled button
+- `Card` – simple container with shadow
+- `Navbar` – top navigation bar

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hobbyhosting/ui",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export interface ButtonProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Button: React.FC<ButtonProps> = ({ children, className = "" }) => {
+  return (
+    <button
+      className={`px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 ${className}`.trim()}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/ui/src/components/Card.tsx
+++ b/packages/ui/src/components/Card.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+export interface CardProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Card: React.FC<CardProps> = ({ children, className = "" }) => {
+  return (
+    <div className={`bg-white shadow rounded p-4 ${className}`.trim()}>
+      {children}
+    </div>
+  );
+};

--- a/packages/ui/src/components/Navbar.tsx
+++ b/packages/ui/src/components/Navbar.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+export interface NavbarProps {
+  title: string;
+}
+
+export const Navbar: React.FC<NavbarProps> = ({ title }) => (
+  <nav className="bg-gray-800 text-white px-4 py-3">
+    <span className="font-semibold">{title}</span>
+  </nav>
+);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./components/Button";
+export * from "./components/Card";
+export * from "./components/Navbar";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "jsx": "react",
+    "declaration": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create Next.js skeleton for admin dashboard under `apps/hobbyhosting-frontend`
- document how to start the dashboard in the main README
- expand `packages/ui` with Card and Navbar components

## Testing
- `make format`
- `make lint`
- `make test` *(fails: `pytest` not found)*