### PR TITLE
Add basic UI component library

### DIFF
--- a/docs/README2.md
+++ b/docs/README2.md
@@ -10,6 +10,8 @@ Ett modernt DevOps-baserat plattformsprojekt byggt med microservices, Docker, Fa
 hobbyhosting/
 ├── apps/                  # Fristående appar (frontend/adminjs etc)
 │   └── hobbyhosting-frontend/
+├── packages/
+│   └── ui/                # Återanvändbara React-komponenter
 ├── services/              # Backend-tjänster
 │   ├── auth_service/
 │   ├── mail_service/
@@ -44,6 +46,7 @@ make health-auth
 ## 🔑 Miljövariabler
 
 Exempel finns i `.env.example`.
+Development and production configs are generated with `./scripts/setup_env.sh`, creating `.env.dev` and `.env.prod`.
 
 ### Mail Service
 
@@ -71,6 +74,22 @@ Exempel finns i `.env.example`.
 - Allt byggs och körs genom `config/docker-compose.yml`
 - Caddy hanterar HTTPS + domäner automatiskt
 - Alla tjänster körs via interna nätverk (`backend`)
+
+---
+
+## 🎨 Frontend & UI
+
+Det finns ett separat paket `packages/ui` som innehåller återanvändbara
+React-komponenter. Installera beroenden och bygg paketet via:
+
+```bash
+cd packages/ui
+npm install
+npm run build
+```
+
+Dessa komponenter kan sedan importeras i admin-frontenden för en enhetlig
+design.
 
 ---
 
@@ -142,6 +161,7 @@ vanligtvis en 404- eller proxy-felkod.
 - Lägga till CI/CD
 - Integrera mailutskick
 - Lägg till docs för hur auth fungerar
+- Bygg vidare på `packages/ui` för delad design
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "private": true,
   "devDependencies": {
     "eslint": "^8.57.0",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "typescript": "^5.3.3",
+    "tailwindcss": "^3.4.3",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@headlessui/react": "^1.7.18",
+    "@heroicons/react": "^2.1.0"
   }
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,0 +1,9 @@
+# @hobbyhosting/ui
+
+Reusable React components for the HobbyHosting admin dashboard.
+
+```
+npm install @hobbyhosting/ui
+```
+
+Currently includes a simple `Button` component styled with Tailwind CSS classes.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hobbyhosting/ui",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "react": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export interface ButtonProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export const Button: React.FC<ButtonProps> = ({ children, className = "" }) => {
+  return (
+    <button
+      className={`px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700 ${className}`.trim()}
+    >
+      {children}
+    </button>
+  );
+};

--- a/packages/ui/src/components/Chat.tsx
+++ b/packages/ui/src/components/Chat.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+
+interface Message {
+  id: number;
+  username: string;
+  message: string;
+  created_at: string;
+}
+
+export interface ChatProps {
+  apiUrl: string;
+  token: string;
+}
+
+export const Chat: React.FC<ChatProps> = ({ apiUrl, token }) => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    fetch(`${apiUrl}/chat/messages`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.json())
+      .then(setMessages)
+      .catch(console.error);
+  }, [apiUrl, token]);
+
+  const sendMessage = async () => {
+    if (!input) return;
+    const resp = await fetch(`${apiUrl}/chat/messages`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ message: input }),
+    });
+    if (resp.ok) {
+      const msg = await resp.json();
+      setMessages((prev) => [...prev, msg]);
+      setInput("");
+    }
+  };
+
+  return (
+    <div className="border rounded p-2">
+      <div className="h-48 overflow-y-auto mb-2">
+        {messages.map((m) => (
+          <div key={m.id}>
+            <strong>{m.username}:</strong> {m.message}
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border px-2 py-1 rounded"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        <button
+          onClick={sendMessage}
+          className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./components/Button";
+export * from "./components/Chat";

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "jsx": "react",
+    "declaration": true,
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a shared Button component library under `packages/ui`
- restore Chat component and export in the UI index
- document env setup in README2

## Testing
- `make format`
- `make lint`
- `make test` *(fails: `pytest` not found)*
