### PR TITLE
Add simple login/register pages

### DIFF
--- a/apps/public_site/login.html
+++ b/apps/public_site/login.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Login</title>
+  </head>
+  <body>
+    <h1>Login</h1>
+    <form id="login-form">
+      <label>
+        Username:
+        <input type="text" id="username" required /> </label
+      ><br />
+      <label>
+        Password:
+        <input type="password" id="password" required /> </label
+      ><br />
+      <button type="submit">Login</button>
+    </form>
+    <p id="message"></p>
+    <script src="login.js"></script>
+  </body>
+</html>

--- a/apps/public_site/login.js
+++ b/apps/public_site/login.js
@@ -1,0 +1,44 @@
+const form = document.getElementById("login-form");
+const message = document.getElementById("message");
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  message.textContent = "";
+  const username = document.getElementById("username").value;
+  const password = document.getElementById("password").value;
+  try {
+    const resp = await fetch("http://localhost:8000/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password }),
+    });
+    const data = await safeJson(resp);
+    if (!resp.ok || !data) {
+      message.style.color = "red";
+      message.textContent = (data && data.detail) || "Login failed";
+      return;
+    }
+    if (data.access_token) {
+      localStorage.setItem("access_token", data.access_token);
+      message.style.color = "green";
+      message.textContent = "Success! Redirecting...";
+      setTimeout(() => {
+        window.location.href = "welcome.html";
+      }, 500);
+    } else {
+      message.style.color = "red";
+      message.textContent = "Unexpected response";
+    }
+  } catch (err) {
+    message.style.color = "red";
+    message.textContent = "Network error";
+  }
+});
+
+async function safeJson(resp) {
+  try {
+    return await resp.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/public_site/register.html
+++ b/apps/public_site/register.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Register</title>
+  </head>
+  <body>
+    <h1>Register</h1>
+    <form id="register-form">
+      <label>
+        Username:
+        <input type="text" id="username" required /> </label
+      ><br />
+      <label>
+        Email:
+        <input type="email" id="email" required /> </label
+      ><br />
+      <label>
+        Password:
+        <input type="password" id="password" required /> </label
+      ><br />
+      <label>
+        <input type="checkbox" id="auto-login" /> Log in after registration </label
+      ><br />
+      <button type="submit">Register</button>
+    </form>
+    <p id="message"></p>
+    <script src="register.js"></script>
+  </body>
+</html>

--- a/apps/public_site/register.js
+++ b/apps/public_site/register.js
@@ -1,0 +1,61 @@
+const form = document.getElementById("register-form");
+const message = document.getElementById("message");
+
+form.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  message.textContent = "";
+  const username = document.getElementById("username").value;
+  const email = document.getElementById("email").value;
+  const password = document.getElementById("password").value;
+  const autoLogin = document.getElementById("auto-login").checked;
+  try {
+    const resp = await fetch("http://localhost:8000/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, email, password }),
+    });
+    const data = await safeJson(resp);
+    if (!resp.ok || !data) {
+      message.style.color = "red";
+      message.textContent = (data && data.detail) || "Registration failed";
+      return;
+    }
+    message.style.color = "green";
+    message.textContent = "Registration successful";
+    if (autoLogin) {
+      await login(username, password);
+    }
+  } catch (err) {
+    message.style.color = "red";
+    message.textContent = "Network error";
+  }
+});
+
+async function login(username, password) {
+  try {
+    const resp = await fetch("http://localhost:8000/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password }),
+    });
+    const data = await safeJson(resp);
+    if (resp.ok && data && data.access_token) {
+      localStorage.setItem("access_token", data.access_token);
+      window.location.href = "welcome.html";
+    } else {
+      message.style.color = "red";
+      message.textContent = (data && data.detail) || "Auto login failed";
+    }
+  } catch {
+    message.style.color = "red";
+    message.textContent = "Network error during auto login";
+  }
+}
+
+async function safeJson(resp) {
+  try {
+    return await resp.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/public_site/welcome.html
+++ b/apps/public_site/welcome.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Welcome</title>
+  </head>
+  <body>
+    <h1>Welcome</h1>
+    <p>You are logged in.</p>
+  </body>
+</html>

--- a/docs/README2.md
+++ b/docs/README2.md
@@ -153,6 +153,16 @@ curl -X POST http://localhost:8000/auth/login \
 Svaret ska vara JSON med ett `access_token`. Ett HTML-svar innebär
 vanligtvis en 404- eller proxy-felkod.
 
+## Använda enkla inloggningssidor
+
+Det finns statiska filer i `apps/public_site` som visar hur du kan logga in
+och registrera dig utan ett fullständigt frontendbygge. Öppna `login.html`
+eller `register.html` i webbläsaren medan auth-tjänsten kör lokalt på
+`http://localhost:8000`. Vid lyckad inloggning sparas `access_token` i
+`localStorage` och du skickas vidare till `welcome.html`. Markerar du rutan
+"Log in after registration" sker inloggningen automatiskt efter lyckad
+registrering.
+
 ---
 
 ## 🛠 TODO (för vidare utveckling)


### PR DESCRIPTION
## Summary
- add minimal login and register pages under `apps/public_site`
- store `access_token` after login and redirect to a welcome page
- allow optional auto-login on registration
- show messages on page instead of using `alert()`
- document usage in `docs/README2.md`

## Testing
- `make format`
- `make lint`
- `make test` *(fails: No module named pytest)*