### PR TITLE
Add pytest convenience wrapper

### DIFF
--- a/bin/pytest
+++ b/bin/pytest
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 -m pytest "$@"


### PR DESCRIPTION
## Summary
- add `bin/pytest` helper calling `python3 -m pytest`

## Testing
- `make lint`
- `make test` *(fails: No module named pytest)*