### PR TITLE
Fix ecom env naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 AUTH_DB=auth_db
 MAIL_DB=mail_db
-ECOMMERCE_DB=ecom_db
+ECOM_DB=ecom_db
 
 # Mail service
 RESEND_API_KEY=

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     container_name: ecom_backend
     env_file: ../services/ecommerce/backend/.env.${COMPOSE_PROFILE:-dev}
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database_service:${POSTGRES_PORT:-5432}/${ECOMMERCE_DB}
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database_service:${POSTGRES_PORT:-5432}/${ECOM_DB}
       - ENV=dev
     depends_on:
       - database

--- a/scripts/apply_all.sh
+++ b/scripts/apply_all.sh
@@ -78,7 +78,7 @@ for ENVF in .env.dev .env.prod; do
 # POSTGRES_PASSWORD=
 # AUTH_DB=
 # MAIL_DB=
-# ECOMMERCE_DB=
+# ECOM_DB=
 EOF
     fi
     echo "  ✓ Skapade $ENVF"

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -19,7 +19,7 @@ for target in .env.dev .env.prod; do
 # POSTGRES_PASSWORD=
 # AUTH_DB=
 # MAIL_DB=
-# ECOMMERCE_DB=
+# ECOM_DB=
 # RESEND_API_KEY=
 # MAIL_FROM=
 # JWT_SECRET=


### PR DESCRIPTION
## Summary
- use `ECOM_DB` consistently in env files and compose

## Testing
- `make format`
- `make lint`
- `make test` *(fails: No module named pytest)*