### PR TITLE
Fix admin_sync_service imports

### DIFF
--- a/services/admin_sync_service/app/crm/__init__.py
+++ b/services/admin_sync_service/app/crm/__init__.py
@@ -1,3 +1,3 @@
-from admin_sync_service.app.crm import models, schemas
+from . import models, schemas
 
 __all__ = ["models", "schemas"]

--- a/services/admin_sync_service/app/crm/models.py
+++ b/services/admin_sync_service/app/crm/models.py
@@ -1,6 +1,7 @@
-from admin_sync_service.app.dependencies import Base
 from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
+
+from ..dependencies import Base
 
 
 class Company(Base):

--- a/services/admin_sync_service/app/crm/routes.py
+++ b/services/admin_sync_service/app/crm/routes.py
@@ -1,10 +1,11 @@
 from typing import List
 
-from admin_sync_service.app.crm import models, schemas
-# 📁 apps/admin_sync_service/app/crm/routes.py
-from admin_sync_service.app.dependencies import get_db
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+
+# 📁 apps/admin_sync_service/app/crm/routes.py
+from ..dependencies import get_db
+from . import models, schemas
 
 router = APIRouter(prefix="/crm", tags=["CRM"])
 


### PR DESCRIPTION
## Summary
- use relative imports in the CRM package of `admin_sync_service`

## Testing
- `make lint`
- `make test` *(fails: No module named pytest)*