### PR TITLE
Add video showcase page

### DIFF
--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Home() {
   return (
@@ -11,8 +11,15 @@ export default function Home() {
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>
         <nav>
-          <Link href="/login"><button>Login</button></Link>
-          <Link href="/register"><button>Register</button></Link>
+          <Link href="/login">
+            <button>Login</button>
+          </Link>
+          <Link href="/register">
+            <button>Register</button>
+          </Link>
+          <Link href="/showcase">
+            <button>Showcase</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import "../styles/globals.css";
+
+export default function Showcase() {
+  return (
+    <div>
+      <header>
+        <h1>HobbyHosting</h1>
+      </header>
+      <main className="container">
+        <h2>Our Work</h2>
+        <p>Check out some of our previous films below.</p>
+        <div className="video-wrapper">
+          <iframe
+            src="https://www.youtube.com/embed/dQw4w9WgXcQ"
+            title="Showcase video"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          ></iframe>
+        </div>
+        <nav>
+          <Link href="/">Home</Link>
+        </nav>
+      </main>
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -50,3 +50,19 @@ nav a {
   color: #4f46e5;
   text-decoration: none;
 }
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- display previous film work in a new Next.js showcase page
- link to the showcase from the home page
- style video embeds

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'jose' & 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6839fdf9ffb48332a1595e6548303d51