### PR TITLE
Add video showcase page

### DIFF
--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Home() {
   return (
@@ -11,8 +11,15 @@ export default function Home() {
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>
         <nav>
-          <Link href="/login"><button>Login</button></Link>
-          <Link href="/register"><button>Register</button></Link>
+          <Link href="/login">
+            <button>Login</button>
+          </Link>
+          <Link href="/register">
+            <button>Register</button>
+          </Link>
+          <Link href="/showcase">
+            <button>Showcase</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link";
+import { useRef, useState } from "react";
+import "../styles/globals.css";
+
+export default function Showcase() {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const toggleMusic = () => {
+    if (audioRef.current) {
+      if (playing) {
+        audioRef.current.pause();
+      } else {
+        audioRef.current.play();
+      }
+      setPlaying(!playing);
+    }
+  };
+
+  return (
+    <div className="showcase-container">
+      <iframe
+        className="showcase-video"
+        src="https://www.youtube.com/embed/dQw4w9WgXcQ?autoplay=1&mute=1"
+        title="Showcase video"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+      <button
+        className="music-toggle"
+        aria-label={playing ? "Turn music off" : "Turn music on"}
+        onClick={toggleMusic}
+      >
+        {playing ? "🔊" : "🔈"}
+      </button>
+      <audio ref={audioRef} src="/music/theme.mp3" loop />
+      <nav className="showcase-nav">
+        <Link href="/">Home</Link>
+      </nav>
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/public/music/theme.mp3
+++ b/apps/hobbyhosting-frontend/public/music/theme.mp3
@@ -1,0 +1,1 @@
+PLACEHOLDER MP3 - replace with actual track

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -50,3 +50,43 @@ nav a {
   color: #4f46e5;
   text-decoration: none;
 }
+
+.showcase-container {
+  position: relative;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.showcase-video {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.music-toggle {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(79, 70, 229, 0.8);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.music-toggle:hover {
+  background-color: rgba(67, 56, 202, 0.8);
+}
+
+.showcase-nav {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}


### PR DESCRIPTION
## Summary
- display previous film work in a new Next.js showcase page
- link to the showcase from the home page
- style video embeds
- autoplay video and optional music with floating toggle

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'jose' & 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6839fdf9ffb48332a1595e6548303d51