### PR TITLE
Fix login/register endpoints for hosted site

### DIFF
--- a/apps/hobbyhosting-frontend/pages/login.tsx
+++ b/apps/hobbyhosting-frontend/pages/login.tsx
@@ -1,37 +1,37 @@
-import { useState } from 'react';
-import Link from 'next/link';
-import '../styles/globals.css';
+import { useState } from "react";
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Login() {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [message, setMessage] = useState('');
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setMessage('');
+    setMessage("");
     try {
-      const resp = await fetch('http://localhost:8000/auth/login', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const resp = await fetch("https://auth.hobbyhosting.org/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password }),
       });
       const data = await resp.json().catch(() => null);
       if (!resp.ok || !data) {
-        setMessage((data && data.detail) || 'Login failed');
+        setMessage((data && data.detail) || "Login failed");
         return;
       }
       if (data.access_token) {
-        localStorage.setItem('access_token', data.access_token);
-        setMessage('Success! Redirecting...');
+        localStorage.setItem("access_token", data.access_token);
+        setMessage("Success! Redirecting...");
         setTimeout(() => {
-          window.location.href = '/welcome';
+          window.location.href = "/welcome";
         }, 500);
       } else {
-        setMessage('Unexpected response');
+        setMessage("Unexpected response");
       }
     } catch {
-      setMessage('Network error');
+      setMessage("Network error");
     }
   }
 
@@ -44,12 +44,23 @@ export default function Login() {
         <h2>Login</h2>
         <form onSubmit={handleSubmit}>
           <label>
-            Username:<br />
-            <input value={username} onChange={e => setUsername(e.target.value)} required />
+            Username:
+            <br />
+            <input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+            />
           </label>
           <label>
-            Password:<br />
-            <input type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+            Password:
+            <br />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
           </label>
           <button type="submit">Login</button>
         </form>

--- a/apps/hobbyhosting-frontend/pages/register.tsx
+++ b/apps/hobbyhosting-frontend/pages/register.tsx
@@ -1,36 +1,36 @@
-import { useState } from 'react';
-import Link from 'next/link';
-import '../styles/globals.css';
+import { useState } from "react";
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Register() {
-  const [username, setUsername] = useState('');
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [autoLogin, setAutoLogin] = useState(false);
-  const [message, setMessage] = useState('');
+  const [message, setMessage] = useState("");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setMessage('');
+    setMessage("");
     try {
-      const resp = await fetch('http://localhost:8000/auth/register', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+      const resp = await fetch("https://auth.hobbyhosting.org/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, email, password }),
       });
       const data = await resp.json().catch(() => null);
       if (!resp.ok || !data) {
-        setMessage((data && data.detail) || 'Registration failed');
+        setMessage((data && data.detail) || "Registration failed");
         return;
       }
       if (autoLogin) {
-        localStorage.setItem('access_token', data.access_token);
-        window.location.href = '/welcome';
+        localStorage.setItem("access_token", data.access_token);
+        window.location.href = "/welcome";
       } else {
-        setMessage('Registration successful');
+        setMessage("Registration successful");
       }
     } catch {
-      setMessage('Network error');
+      setMessage("Network error");
     }
   }
 
@@ -43,19 +43,41 @@ export default function Register() {
         <h2>Register</h2>
         <form onSubmit={handleSubmit}>
           <label>
-            Username:<br />
-            <input value={username} onChange={e => setUsername(e.target.value)} required />
+            Username:
+            <br />
+            <input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+            />
           </label>
           <label>
-            Email:<br />
-            <input type="email" value={email} onChange={e => setEmail(e.target.value)} required />
+            Email:
+            <br />
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
           </label>
           <label>
-            Password:<br />
-            <input type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+            Password:
+            <br />
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
           </label>
           <label>
-            <input type="checkbox" checked={autoLogin} onChange={e => setAutoLogin(e.target.checked)} /> Log in after registration
+            <input
+              type="checkbox"
+              checked={autoLogin}
+              onChange={(e) => setAutoLogin(e.target.checked)}
+            />{" "}
+            Log in after registration
           </label>
           <button type="submit">Register</button>
         </form>

--- a/apps/public_site/login.js
+++ b/apps/public_site/login.js
@@ -7,7 +7,7 @@ form.addEventListener("submit", async (e) => {
   const username = document.getElementById("username").value;
   const password = document.getElementById("password").value;
   try {
-    const resp = await fetch("http://localhost:8000/auth/login", {
+    const resp = await fetch("https://auth.hobbyhosting.org/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),

--- a/apps/public_site/register.js
+++ b/apps/public_site/register.js
@@ -9,7 +9,7 @@ form.addEventListener("submit", async (e) => {
   const password = document.getElementById("password").value;
   const autoLogin = document.getElementById("auto-login").checked;
   try {
-    const resp = await fetch("http://localhost:8000/auth/register", {
+    const resp = await fetch("https://auth.hobbyhosting.org/auth/register", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, email, password }),
@@ -33,7 +33,7 @@ form.addEventListener("submit", async (e) => {
 
 async function login(username, password) {
   try {
-    const resp = await fetch("http://localhost:8000/auth/login", {
+    const resp = await fetch("https://auth.hobbyhosting.org/auth/login", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),


### PR DESCRIPTION
## Summary
- point public site login and register pages to hosted auth service
- update Next.js pages to use hosted auth service

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for jose and httpx)*
- `pre-commit run --files apps/public_site/login.js apps/public_site/register.js apps/hobbyhosting-frontend/pages/login.tsx apps/hobbyhosting-frontend/pages/register.tsx` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839fd8f67748332831e1648665d051d