### PR TITLE
Add immersive video showcase with music toggle

### DIFF
--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Home() {
   return (
@@ -11,8 +11,15 @@ export default function Home() {
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>
         <nav>
-          <Link href="/login"><button>Login</button></Link>
-          <Link href="/register"><button>Register</button></Link>
+          <Link href="/login">
+            <button>Login</button>
+          </Link>
+          <Link href="/register">
+            <button>Register</button>
+          </Link>
+          <Link href="/showcase">
+            <button>Showcase</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,0 +1,69 @@
+import { useRef, useState } from "react";
+import Link from "next/link";
+import "../styles/globals.css";
+
+export default function Showcase() {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const toggleMusic = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (playing) {
+      audio.pause();
+    } else {
+      audio.play();
+    }
+    setPlaying(!playing);
+  };
+
+  return (
+    <div className="showcase-page">
+      <header>
+        <h1>HobbyHosting</h1>
+      </header>
+      <main>
+        <section className="video-section">
+          <h2>GP-Motor - Bilhandlare i Strängnäs.</h2>
+          <video
+            className="full-video"
+            src="/videos/video1.mp4"
+            autoPlay
+            muted
+            playsInline
+            loop
+          />
+        </section>
+        <section className="video-section">
+          <h2>Olivträdgården - Olivträd av premium kvalité.</h2>
+          <video
+            className="full-video"
+            src="/videos/video2.mp4"
+            autoPlay
+            muted
+            playsInline
+            loop
+          />
+        </section>
+        <section className="video-section">
+          <h2>Grekiska Tavernan - Restaurang i Strängnäs hamn.</h2>
+          <video
+            className="full-video"
+            src="/videos/video3.mp4"
+            autoPlay
+            muted
+            playsInline
+            loop
+          />
+        </section>
+        <nav>
+          <Link href="/">Home</Link>
+        </nav>
+      </main>
+      <button className="music-toggle" onClick={toggleMusic}>
+        {playing ? "Music Off" : "Music On"}
+      </button>
+      <audio ref={audioRef} src="/music/theme.mp3" loop />
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/public/music/theme.mp3
+++ b/apps/hobbyhosting-frontend/public/music/theme.mp3
@@ -1,0 +1,1 @@
+Placeholder MP3

--- a/apps/hobbyhosting-frontend/public/videos/video1.mp4
+++ b/apps/hobbyhosting-frontend/public/videos/video1.mp4
@@ -1,0 +1,1 @@
+Placeholder MP4 1

--- a/apps/hobbyhosting-frontend/public/videos/video2.mp4
+++ b/apps/hobbyhosting-frontend/public/videos/video2.mp4
@@ -1,0 +1,1 @@
+Placeholder MP4 2

--- a/apps/hobbyhosting-frontend/public/videos/video3.mp4
+++ b/apps/hobbyhosting-frontend/public/videos/video3.mp4
@@ -1,0 +1,1 @@
+Placeholder MP4 3

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -50,3 +50,50 @@ nav a {
   color: #4f46e5;
   text-decoration: none;
 }
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+/* Showcase page styles */
+.showcase-page {
+  text-align: center;
+}
+
+.video-section {
+  margin-bottom: 2rem;
+}
+
+.full-video {
+  width: 100%;
+  height: auto;
+}
+
+.music-toggle {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 1000;
+  background-color: #4f46e5;
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  cursor: pointer;
+}
+
+.music-toggle:hover {
+  background-color: #4338ca;
+}


### PR DESCRIPTION
## Summary
- create public folders for showcase media
- display three autoplaying videos with project descriptions
- add floating music toggle button for optional background audio

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for `jose` and `httpx`)*

------
https://chatgpt.com/codex/tasks/task_e_6839fdf9ffb48332a1595e6548303d51