### PR TITLE
Add admin file upload API

### DIFF
--- a/apps/admin_panel/README.md
+++ b/apps/admin_panel/README.md
@@ -1,3 +1,5 @@
 # Admin Panel
 
 This is a lightweight placeholder for the admin panel application. It allows Docker Compose builds to succeed when the real implementation is missing.
+
+The page now includes a basic file upload form that interacts with the `/files` API in the `admin_sync_service`. Uploaded files are listed below the form and can be downloaded by other admins.

--- a/apps/admin_panel/index.html
+++ b/apps/admin_panel/index.html
@@ -7,5 +7,50 @@
   <body>
     <h1>Admin Panel Placeholder</h1>
     <p>This is a placeholder for the admin panel.</p>
+
+    <h2>Upload File</h2>
+    <form id="uploadForm">
+      <input type="file" name="upload_file" />
+      <button type="submit">Upload</button>
+    </form>
+
+    <h2>Files</h2>
+    <ul id="files"></ul>
+
+    <script>
+      async function loadFiles() {
+        const resp = await fetch("http://localhost:8000/files");
+        if (!resp.ok) return;
+        const files = await resp.json();
+        const list = document.getElementById("files");
+        list.innerHTML = "";
+        files.forEach((f) => {
+          const li = document.createElement("li");
+          const link = document.createElement("a");
+          link.href = `http://localhost:8000/files/${f.id}/download`;
+          link.textContent = f.filename;
+          li.appendChild(link);
+          li.appendChild(
+            document.createTextNode(` (uploaded by ${f.uploaded_by})`),
+          );
+          list.appendChild(li);
+        });
+      }
+
+      document
+        .getElementById("uploadForm")
+        .addEventListener("submit", async (e) => {
+          e.preventDefault();
+          const formData = new FormData(e.target);
+          await fetch("http://localhost:8000/files", {
+            method: "POST",
+            body: formData,
+          });
+          e.target.reset();
+          loadFiles();
+        });
+
+      loadFiles();
+    </script>
   </body>
 </html>

--- a/services/admin_sync_service/app/files/models.py
+++ b/services/admin_sync_service/app/files/models.py
@@ -1,0 +1,14 @@
+from datetime import datetime
+
+from admin_sync_service.app.dependencies import Base
+from sqlalchemy import Column, DateTime, Integer, String
+
+
+class AdminFile(Base):
+    __tablename__ = "admin_files"
+
+    id = Column(Integer, primary_key=True, index=True)
+    filename = Column(String, nullable=False)
+    filepath = Column(String, nullable=False)
+    uploaded_by = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)

--- a/services/admin_sync_service/app/files/routes.py
+++ b/services/admin_sync_service/app/files/routes.py
@@ -1,0 +1,54 @@
+import os
+
+from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi.responses import FileResponse
+from sqlalchemy.orm import Session
+
+from ..dependencies import get_db
+from ..main import verify_token
+from . import models, schemas
+
+UPLOAD_DIR = os.getenv(
+    "UPLOAD_DIR", os.path.join(os.path.dirname(__file__), "../../uploads")
+)
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+router = APIRouter(prefix="/files", tags=["Files"])
+
+
+@router.post("", response_model=schemas.FileOut)
+async def upload_file(
+    upload_file: UploadFile = File(...),
+    username: str = Depends(verify_token),
+    db: Session = Depends(get_db),
+):
+    file_location = os.path.join(UPLOAD_DIR, upload_file.filename)
+    with open(file_location, "wb") as f:
+        content = await upload_file.read()
+        f.write(content)
+    db_file = models.AdminFile(
+        filename=upload_file.filename,
+        filepath=file_location,
+        uploaded_by=username,
+    )
+    db.add(db_file)
+    db.commit()
+    db.refresh(db_file)
+    return db_file
+
+
+@router.get("", response_model=list[schemas.FileOut])
+async def list_files(
+    username: str = Depends(verify_token), db: Session = Depends(get_db)
+):
+    return db.query(models.AdminFile).all()
+
+
+@router.get("/{file_id}/download")
+async def download_file(
+    file_id: int, username: str = Depends(verify_token), db: Session = Depends(get_db)
+):
+    db_file = db.query(models.AdminFile).filter(models.AdminFile.id == file_id).first()
+    if not db_file:
+        return FileResponse(path=None, status_code=404)
+    return FileResponse(path=db_file.filepath, filename=db_file.filename)

--- a/services/admin_sync_service/app/files/schemas.py
+++ b/services/admin_sync_service/app/files/schemas.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class FileOut(BaseModel):
+    id: int
+    filename: str
+    uploaded_by: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/services/admin_sync_service/app/main.py
+++ b/services/admin_sync_service/app/main.py
@@ -7,6 +7,7 @@ from admin_sync_service.app.chat.schemas import (ChatMessageCreate,
                                                  ChatMessageOut)
 from admin_sync_service.app.crm.routes import router as crm_router
 from admin_sync_service.app.dependencies import Base, engine, get_db
+from admin_sync_service.app.files.routes import router as files_router
 from admin_sync_service.app.sync.models import Sync
 from admin_sync_service.app.sync.schemas import SyncCreate
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -163,3 +164,4 @@ async def list_chat_messages(
 
 # CRM router
 app.include_router(crm_router)
+app.include_router(files_router)

--- a/tests/test_admin_files.py
+++ b/tests/test_admin_files.py
@@ -1,0 +1,31 @@
+import os
+from jose import jwt
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_sync.db")
+
+from admin_sync_service.app.main import app
+
+client = TestClient(app)
+SECRET = "supersecret"
+
+
+def make_token():
+    return jwt.encode({"sub": "admin@hobbyhosting.org", "is_admin": True}, SECRET, algorithm="HS256")
+
+
+def test_file_upload_and_list():
+    token = make_token()
+    resp = client.post(
+        "/files",
+        headers={"Authorization": f"Bearer {token}"},
+        files={"upload_file": ("test.txt", b"hello", "text/plain")},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["filename"] == "test.txt"
+
+    list_resp = client.get("/files", headers={"Authorization": f"Bearer {token}"})
+    assert list_resp.status_code == 200
+    files = list_resp.json()
+    assert any(f["filename"] == "test.txt" for f in files)


### PR DESCRIPTION
## Summary
- add upload interface in admin panel placeholder
- document placeholder upload functionality
- implement `/files` API with CRUD for admin file sharing
- include new test for file upload

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for `jose` and `httpx`)*

------
https://chatgpt.com/codex/tasks/task_e_683a02c9b1d88332aef6468595374173