### PR TITLE
Add simple Stripe checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,6 @@ RESEND_API_KEY=
 MAIL_FROM=noreply@hobbyhosting.org
 JWT_SECRET=supersecret
 JWT_ALGO=HS256
+
+# Stripe
+STRIPE_SECRET_KEY=

--- a/apps/hobbyhosting-frontend/pages/api/create-checkout-session.ts
+++ b/apps/hobbyhosting-frontend/pages/api/create-checkout-session.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import Stripe from "stripe";
+
+const stripeSecret = process.env.STRIPE_SECRET_KEY;
+const stripe = stripeSecret
+  ? new Stripe(stripeSecret, { apiVersion: "2023-10-16" })
+  : null;
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    res.status(405).end("Method Not Allowed");
+    return;
+  }
+
+  if (!stripe) {
+    res.status(500).json({ error: "Stripe not configured" });
+    return;
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ["card"],
+      mode: "payment",
+      line_items: [
+        {
+          price_data: {
+            currency: "usd",
+            unit_amount: 50000,
+            product_data: { name: "We film your business" },
+          },
+          quantity: 1,
+        },
+      ],
+      success_url: `${req.headers.origin}/film?success=true`,
+      cancel_url: `${req.headers.origin}/film?canceled=true`,
+    });
+
+    res.status(200).json({ url: session.url });
+  } catch {
+    res.status(500).json({ error: "Failed to create session" });
+  }
+}

--- a/apps/hobbyhosting-frontend/pages/film.tsx
+++ b/apps/hobbyhosting-frontend/pages/film.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { useRouter } from "next/router";
+import "../styles/globals.css";
+
+export default function Film() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (router.query.success) setMessage("Payment successful!");
+    if (router.query.canceled) setMessage("Payment canceled.");
+  }, [router.query]);
+
+  async function handleCheckout() {
+    setLoading(true);
+    setMessage("");
+    const resp = await fetch("/api/create-checkout-session", {
+      method: "POST",
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      if (data.url) {
+        window.location.href = data.url;
+        return;
+      }
+    }
+    setLoading(false);
+    setMessage("Unable to start checkout");
+  }
+
+  return (
+    <div>
+      <header>
+        <h1>HobbyHosting</h1>
+      </header>
+      <main className="container">
+        <h2>We film your business</h2>
+        <p>Get a professional promo video for $500.</p>
+        <button onClick={handleCheckout} disabled={loading}>
+          {loading ? "Loading..." : "Buy Now"}
+        </button>
+        {message && <p id="message">{message}</p>}
+        <nav>
+          <a href="/">Home</a>
+        </nav>
+      </main>
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -20,6 +20,9 @@ export default function Home() {
           <Link href="/showcase">
             <button>Showcase</button>
           </Link>
+          <Link href="/film">
+            <button>Film your business</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@headlessui/react": "^1.7.18",
-    "@heroicons/react": "^2.1.0"
+    "@heroicons/react": "^2.1.0",
+    "stripe": "^13.0.0",
+    "@stripe/stripe-js": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Stripe checkout API route
- create a one-page product with checkout
- link new page from the front page
- document STRIPE_SECRET_KEY env var
- add Stripe packages

## Testing
- `make format`
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_683a036007c48332a297f74231e76f22