### PR TITLE
Document admin interface

### DIFF
--- a/apps/admin_panel/README.md
+++ b/apps/admin_panel/README.md
@@ -1,3 +1,5 @@
 # Admin Panel
 
-This is a lightweight placeholder for the admin panel application. It allows Docker Compose builds to succeed when the real implementation is missing.
+This directory now contains a small static admin interface for managing users.
+Open `index.html` directly or serve it with a simple HTTP server to list users
+from the authentication service and promote or demote them to admin status.

--- a/apps/admin_panel/index.html
+++ b/apps/admin_panel/index.html
@@ -2,10 +2,98 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>Admin Panel Placeholder</title>
+    <title>Admin Panel</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 20px;
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      th,
+      td {
+        border: 1px solid #ccc;
+        padding: 8px;
+        text-align: left;
+      }
+      button {
+        margin-right: 5px;
+      }
+    </style>
   </head>
   <body>
-    <h1>Admin Panel Placeholder</h1>
-    <p>This is a placeholder for the admin panel.</p>
+    <h1>User Administration</h1>
+    <p id="status"></p>
+    <table id="users">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Admin</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <script>
+      async function fetchUsers() {
+        const token = localStorage.getItem("access_token");
+        if (!token) {
+          document.getElementById("status").textContent =
+            "Please log in first.";
+          return;
+        }
+        const resp = await fetch("https://auth.hobbyhosting.org/users", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!resp.ok) {
+          document.getElementById("status").textContent =
+            "Failed to load users";
+          return;
+        }
+        const data = await resp.json();
+        const tbody = document.querySelector("#users tbody");
+        tbody.innerHTML = "";
+        data.forEach((u) => {
+          const tr = document.createElement("tr");
+          const admin = u.is_admin;
+          tr.innerHTML =
+            `<td>${u.username}</td>` +
+            `<td>${admin ? "Yes" : "No"}</td>` +
+            `<td></td>`;
+          const actions = document.createElement("td");
+          const btn = document.createElement("button");
+          btn.textContent = admin ? "Demote" : "Promote";
+          btn.onclick = () => toggleAdmin(u.username, admin);
+          actions.appendChild(btn);
+          tr.replaceChild(actions, tr.children[2]);
+          tbody.appendChild(tr);
+        });
+      }
+
+      async function toggleAdmin(username, isAdmin) {
+        const token = localStorage.getItem("access_token");
+        const endpoint = isAdmin ? "demote" : "promote";
+        const resp = await fetch(
+          `https://auth.hobbyhosting.org/auth/${endpoint}`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ username }),
+          },
+        );
+        if (resp.ok) {
+          fetchUsers();
+        } else {
+          alert("Operation failed");
+        }
+      }
+
+      fetchUsers();
+    </script>
   </body>
 </html>

--- a/docs/README2.md
+++ b/docs/README2.md
@@ -10,7 +10,7 @@ Ett modernt DevOps-baserat plattformsprojekt byggt med microservices, Docker, Fa
 hobbyhosting/
 ├── apps/                  # Fristående frontends
 │   ├── public_site/       # Enkel statisk sida
-│   ├── admin_panel/       # Minimal adminpanel
+│   ├── admin_panel/       # Statisk adminpanel med användarhantering
 │   └── hobbyhosting-frontend/  # Legacy Next.js-projekt (tomt)
 ├── packages/
 │   └── ui/                # Återanvändbara React-komponenter
@@ -96,7 +96,8 @@ design.
 Frontend-apparna ligger under `apps/` och består av rena statiska filer:
 
 - `public_site/` – enkel publiksida
-- `admin_panel/` – lättviktigt admin-gränssnitt
+- `admin_panel/` – statisk sida med användarlista och knappar för att
+  promota/demota admins
 
 Starta dem genom att öppna `index.html` direkt eller kör en simpel HTTP-server:
 


### PR DESCRIPTION
## Summary
- describe new admin panel behavior
- clarify docs for static admin panel

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError for `jose`/`httpx`)*

------
https://chatgpt.com/codex/tasks/task_e_683a0279c76083329a51ac2a82a5080f