### PR TITLE
Add video showcase page

### DIFF
--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Home() {
   return (
@@ -11,8 +11,15 @@ export default function Home() {
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>
         <nav>
-          <Link href="/login"><button>Login</button></Link>
-          <Link href="/register"><button>Register</button></Link>
+          <Link href="/login">
+            <button>Login</button>
+          </Link>
+          <Link href="/register">
+            <button>Register</button>
+          </Link>
+          <Link href="/showcase">
+            <button>Showcase</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,0 +1,63 @@
+import { useRef, useState } from "react";
+import Link from "next/link";
+import "../styles/globals.css";
+
+const projects = [
+  {
+    title: "GP-Motor - Bilhandlare i Strängnäs.",
+    embedUrl:
+      "https://player.vimeo.com/video/1089182703?autoplay=1&muted=1&loop=1",
+  },
+  {
+    title: "Olivträdgården - Olivträd av premium kvalité.",
+    embedUrl:
+      "https://player.vimeo.com/video/1089182703?autoplay=1&muted=1&loop=1",
+  },
+  {
+    title: "Grekiska Tavernan - Restaurang i Strängnäs hamn.",
+    embedUrl:
+      "https://player.vimeo.com/video/1089182703?autoplay=1&muted=1&loop=1",
+  },
+];
+
+export default function Showcase() {
+  const [musicOn, setMusicOn] = useState(false);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const toggleMusic = () => {
+    if (!audioRef.current) return;
+    if (musicOn) {
+      audioRef.current.pause();
+    } else {
+      audioRef.current.play();
+    }
+    setMusicOn(!musicOn);
+  };
+
+  return (
+    <div>
+      <header>
+        <h1>HobbyHosting</h1>
+        <nav>
+          <Link href="/">Home</Link>
+        </nav>
+      </header>
+      {projects.map((project) => (
+        <section key={project.title} className="video-section">
+          <div className="video-text">{project.title}</div>
+          {/* To use your own MP4 files, place them under /public/videos and swap
+              this iframe for a <video> element */}
+          <iframe
+            src={project.embedUrl}
+            allow="autoplay; fullscreen; picture-in-picture"
+            allowFullScreen
+          ></iframe>
+        </section>
+      ))}
+      <button className="music-toggle" onClick={toggleMusic}>
+        {musicOn ? "Turn music off" : "Turn music on"}
+      </button>
+      <audio ref={audioRef} src="/music/theme.mp3" loop />
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/public/music/theme.mp3
+++ b/apps/hobbyhosting-frontend/public/music/theme.mp3
@@ -1,0 +1,1 @@
+placeholder mp3

--- a/apps/hobbyhosting-frontend/public/videos/video1.mp4
+++ b/apps/hobbyhosting-frontend/public/videos/video1.mp4
@@ -1,0 +1,1 @@
+placeholder mp4

--- a/apps/hobbyhosting-frontend/public/videos/video2.mp4
+++ b/apps/hobbyhosting-frontend/public/videos/video2.mp4
@@ -1,0 +1,1 @@
+placeholder mp4

--- a/apps/hobbyhosting-frontend/public/videos/video3.mp4
+++ b/apps/hobbyhosting-frontend/public/videos/video3.mp4
@@ -1,0 +1,1 @@
+placeholder mp4

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -50,3 +50,54 @@ nav a {
   color: #4f46e5;
   text-decoration: none;
 }
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-section {
+  position: relative;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.video-section iframe,
+.video-section video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border: none;
+}
+
+.video-text {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  color: white;
+  font-size: 1.5rem;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.7);
+}
+
+.music-toggle {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- display three project videos with overlay text in a new showcase page
- autoplay videos from Vimeo with a floating music toggle
- add styles for fullscreen sections and a fixed music button

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'jose' & 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6839fdf9ffb48332a1595e6548303d51