### PR TITLE
Add immersive video showcase page

### DIFF
--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Home() {
   return (
@@ -11,8 +11,15 @@ export default function Home() {
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>
         <nav>
-          <Link href="/login"><button>Login</button></Link>
-          <Link href="/register"><button>Register</button></Link>
+          <Link href="/login">
+            <button>Login</button>
+          </Link>
+          <Link href="/register">
+            <button>Register</button>
+          </Link>
+          <Link href="/showcase">
+            <button>Showcase</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,0 +1,63 @@
+import { useRef, useState } from "react";
+import Link from "next/link";
+import "../styles/globals.css";
+
+const videos = [
+  {
+    title: "GP-Motor - Bilhandlare i Strängnäs.",
+    url: "https://player.vimeo.com/video/1089182703?autoplay=1&muted=1&loop=1",
+  },
+  {
+    title: "Olivträdgården - Olivträd av premium kvalité.",
+    url: "https://player.vimeo.com/video/1089182703?autoplay=1&muted=1&loop=1",
+  },
+  {
+    title: "Grekiska Tavernan - Restaurang i Strängnäs hamn.",
+    url: "https://player.vimeo.com/video/1089182703?autoplay=1&muted=1&loop=1",
+  },
+];
+
+export default function Showcase() {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [musicOn, setMusicOn] = useState(false);
+
+  const toggleMusic = () => {
+    if (!audioRef.current) return;
+    if (musicOn) {
+      audioRef.current.pause();
+    } else {
+      audioRef.current.play().catch(() => {});
+    }
+    setMusicOn(!musicOn);
+  };
+
+  return (
+    <div>
+      <header>
+        <h1>HobbyHosting</h1>
+      </header>
+      <main>
+        {videos.map((video) => (
+          <section key={video.title} className="video-section">
+            <h2>{video.title}</h2>
+            <div className="video-wrapper">
+              <iframe
+                src={video.url}
+                allow="autoplay; fullscreen"
+                allowFullScreen
+                title={video.title}
+              />
+            </div>
+          </section>
+        ))}
+        <button className="music-toggle" onClick={toggleMusic}>
+          {musicOn ? "Turn music off" : "Turn music on"}
+        </button>
+        <audio ref={audioRef} src="/music/theme.mp3" loop />
+        <nav>
+          <Link href="/">Home</Link>
+        </nav>
+      </main>
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/public/music/README.md
+++ b/apps/hobbyhosting-frontend/public/music/README.md
@@ -1,0 +1,1 @@
+Add background music file named theme.mp3

--- a/apps/hobbyhosting-frontend/public/videos/README.md
+++ b/apps/hobbyhosting-frontend/public/videos/README.md
@@ -1,0 +1,1 @@
+Add your video files here: video1.mp4, video2.mp4, video3.mp4

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -50,3 +50,42 @@ nav a {
   color: #4f46e5;
   text-decoration: none;
 }
+
+.video-section {
+  position: relative;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.video-section h2 {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  z-index: 1;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+}
+
+.video-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.video-wrapper iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.music-toggle {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  z-index: 2;
+}


### PR DESCRIPTION
## Summary
- introduce a fullscreen showcase with three autoplaying videos
- allow visitors to toggle background music via a floating button
- add placeholder directories for videos and music

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'jose' & 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6839fdf9ffb48332a1595e6548303d51