### PR TITLE
Add immersive showcase page

### DIFF
--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Home() {
   return (
@@ -11,8 +11,15 @@ export default function Home() {
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>
         <nav>
-          <Link href="/login"><button>Login</button></Link>
-          <Link href="/register"><button>Register</button></Link>
+          <Link href="/login">
+            <button>Login</button>
+          </Link>
+          <Link href="/register">
+            <button>Register</button>
+          </Link>
+          <Link href="/showcase">
+            <button>Showcase</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,0 +1,54 @@
+import { useRef, useState } from "react";
+import Link from "next/link";
+import "../styles/globals.css";
+
+const projects = [
+  "GP-Motor - Bilhandlare i Strängnäs.",
+  "Olivträdgården - Olivträd av premium kvalité.",
+  "Grekiska Tavernan - Restaurang i Strängnäs hamn.",
+];
+
+export default function Showcase() {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const toggleMusic = () => {
+    if (!audioRef.current) return;
+    if (playing) {
+      audioRef.current.pause();
+    } else {
+      audioRef.current.play();
+    }
+    setPlaying(!playing);
+  };
+
+  return (
+    <div>
+      <header>
+        <h1>Vårt Arbete</h1>
+      </header>
+      <main>
+        {projects.map((title, idx) => (
+          <section key={idx} className="video-section">
+            <h2>{title}</h2>
+            <div className="video-wrapper">
+              <iframe
+                src="https://player.vimeo.com/video/1089182703?autoplay=1&muted=1&loop=1&background=1"
+                allow="autoplay; fullscreen"
+                allowFullScreen
+                title={title}
+              ></iframe>
+            </div>
+          </section>
+        ))}
+        <nav>
+          <Link href="/">Home</Link>
+        </nav>
+      </main>
+      <audio ref={audioRef} loop src="/music/theme.mp3" />
+      <button onClick={toggleMusic} className="music-toggle">
+        {playing ? "Turn off music" : "Play music"}
+      </button>
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/public/music/README.md
+++ b/apps/hobbyhosting-frontend/public/music/README.md
@@ -1,0 +1,1 @@
+Place an MP3 file named `theme.mp3` here to use as optional background music on the showcase page.

--- a/apps/hobbyhosting-frontend/public/videos/README.md
+++ b/apps/hobbyhosting-frontend/public/videos/README.md
@@ -1,0 +1,2 @@
+Place three MP4 files here named `video1.mp4`, `video2.mp4`, and `video3.mp4`.
+These videos will be used on the showcase page.

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -50,3 +50,39 @@ nav a {
   color: #4f46e5;
   text-decoration: none;
 }
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-section {
+  position: relative;
+  height: 100vh;
+  padding: 2rem;
+  background: #000;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.music-toggle {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- create placeholder directories for showcase media
- autoplay three Vimeo sections describing our work
- add floating music toggle
- style fullscreen video sections

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: 'jose', 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6839fdf9ffb48332a1595e6548303d51