### PR TITLE
Add global header menu

### DIFF
--- a/apps/hobbyhosting-frontend/components/Header.tsx
+++ b/apps/hobbyhosting-frontend/components/Header.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import "../styles/globals.css";
+
+const links = [
+  { href: "/", label: "Home" },
+  { href: "/login", label: "Login" },
+  { href: "/register", label: "Register" },
+  { href: "/showcase", label: "Showcase" },
+  { href: "/film", label: "Film" },
+  { href: "/welcome", label: "Welcome" },
+];
+
+export default function Header() {
+  return (
+    <header>
+      <h1>HobbyHosting</h1>
+      <nav>
+        {links.map(({ href, label }) => (
+          <Link key={href} href={href}>
+            {label}
+          </Link>
+        ))}
+      </nav>
+    </header>
+  );
+}

--- a/apps/hobbyhosting-frontend/pages/film.tsx
+++ b/apps/hobbyhosting-frontend/pages/film.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/router";
+import Header from "../components/Header";
 import "../styles/globals.css";
 
 export default function Film() {
@@ -31,9 +32,7 @@ export default function Film() {
 
   return (
     <div>
-      <header>
-        <h1>HobbyHosting</h1>
-      </header>
+      <Header />
       <main className="container">
         <h2>We film your business</h2>
         <p>Get a professional promo video for $500.</p>

--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,12 +1,11 @@
 import Link from "next/link";
+import Header from "../components/Header";
 import "../styles/globals.css";
 
 export default function Home() {
   return (
     <div>
-      <header>
-        <h1>HobbyHosting</h1>
-      </header>
+      <Header />
       <main className="container">
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>

--- a/apps/hobbyhosting-frontend/pages/login.tsx
+++ b/apps/hobbyhosting-frontend/pages/login.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Link from "next/link";
+import Header from "../components/Header";
 import "../styles/globals.css";
 
 export default function Login() {
@@ -37,9 +38,7 @@ export default function Login() {
 
   return (
     <div>
-      <header>
-        <h1>HobbyHosting</h1>
-      </header>
+      <Header />
       <main className="container">
         <h2>Login</h2>
         <form onSubmit={handleSubmit}>

--- a/apps/hobbyhosting-frontend/pages/register.tsx
+++ b/apps/hobbyhosting-frontend/pages/register.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import Link from "next/link";
+import Header from "../components/Header";
 import "../styles/globals.css";
 
 export default function Register() {
@@ -36,9 +37,7 @@ export default function Register() {
 
   return (
     <div>
-      <header>
-        <h1>HobbyHosting</h1>
-      </header>
+      <Header />
       <main className="container">
         <h2>Register</h2>
         <form onSubmit={handleSubmit}>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,12 +1,11 @@
 import Link from "next/link";
+import Header from "../components/Header";
 import "../styles/globals.css";
 
 export default function Showcase() {
   return (
     <div>
-      <header>
-        <h1>HobbyHosting</h1>
-      </header>
+      <Header />
       <main className="container">
         <h2>Our Work</h2>
         <p>Check out some of our previous films below.</p>

--- a/apps/hobbyhosting-frontend/pages/welcome.tsx
+++ b/apps/hobbyhosting-frontend/pages/welcome.tsx
@@ -1,12 +1,11 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import Header from "../components/Header";
+import "../styles/globals.css";
 
 export default function Welcome() {
   return (
     <div>
-      <header>
-        <h1>HobbyHosting</h1>
-      </header>
+      <Header />
       <main className="container">
         <h2>Welcome</h2>
         <p>You are logged in.</p>

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -9,7 +9,23 @@ header {
   background-color: #4f46e5;
   color: #fff;
   padding: 1rem 2rem;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+header h1 {
+  margin: 0;
+}
+
+header nav a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+header nav a:hover {
+  text-decoration: underline;
 }
 main {
   padding: 2rem;

--- a/apps/public_site/index.html
+++ b/apps/public_site/index.html
@@ -8,6 +8,12 @@
   <body>
     <header>
       <h1>HobbyHosting</h1>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="login.html">Login</a>
+        <a href="register.html">Register</a>
+        <a href="welcome.html">Welcome</a>
+      </nav>
     </header>
     <main class="container">
       <h2>Welcome to HobbyHosting</h2>

--- a/apps/public_site/login.html
+++ b/apps/public_site/login.html
@@ -8,6 +8,12 @@
   <body>
     <header>
       <h1>HobbyHosting</h1>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="login.html">Login</a>
+        <a href="register.html">Register</a>
+        <a href="welcome.html">Welcome</a>
+      </nav>
     </header>
     <main class="container">
       <h2>Login</h2>

--- a/apps/public_site/register.html
+++ b/apps/public_site/register.html
@@ -8,6 +8,12 @@
   <body>
     <header>
       <h1>HobbyHosting</h1>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="login.html">Login</a>
+        <a href="register.html">Register</a>
+        <a href="welcome.html">Welcome</a>
+      </nav>
     </header>
     <main class="container">
       <h2>Register</h2>

--- a/apps/public_site/style.css
+++ b/apps/public_site/style.css
@@ -9,7 +9,23 @@ header {
   background-color: #4f46e5;
   color: #fff;
   padding: 1rem 2rem;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+header h1 {
+  margin: 0;
+}
+
+header nav a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+header nav a:hover {
+  text-decoration: underline;
 }
 main {
   padding: 2rem;

--- a/apps/public_site/welcome.html
+++ b/apps/public_site/welcome.html
@@ -8,6 +8,12 @@
   <body>
     <header>
       <h1>HobbyHosting</h1>
+      <nav>
+        <a href="index.html">Home</a>
+        <a href="login.html">Login</a>
+        <a href="register.html">Register</a>
+        <a href="welcome.html">Welcome</a>
+      </nav>
     </header>
     <main class="container">
       <h2>Welcome</h2>


### PR DESCRIPTION
## Summary
- add shared Header component with navigation
- style header for a cleaner look
- use the new header in all Next.js pages
- add matching header menu in the simple HTML site

## Testing
- `make format`
- `make lint`
- `make test` *(fails: ModuleNotFoundError for jose/httpx)*

------
https://chatgpt.com/codex/tasks/task_e_683a08ec0c1c8332b7f9222a53ee67cf