### PR TITLE
Add video showcase page

### DIFF
--- a/apps/hobbyhosting-frontend/pages/index.tsx
+++ b/apps/hobbyhosting-frontend/pages/index.tsx
@@ -1,5 +1,5 @@
-import Link from 'next/link';
-import '../styles/globals.css';
+import Link from "next/link";
+import "../styles/globals.css";
 
 export default function Home() {
   return (
@@ -11,8 +11,12 @@ export default function Home() {
         <h2>Welcome to HobbyHosting</h2>
         <p>Your home for simple app hosting.</p>
         <nav>
-          <Link href="/login"><button>Login</button></Link>
-          <Link href="/register"><button>Register</button></Link>
+          <Link href="/login">
+            <button>Login</button>
+          </Link>
+          <Link href="/register">
+            <button>Register</button>
+          </Link>
         </nav>
       </main>
     </div>

--- a/apps/hobbyhosting-frontend/pages/showcase.tsx
+++ b/apps/hobbyhosting-frontend/pages/showcase.tsx
@@ -1,0 +1,56 @@
+import { useRef, useState } from "react";
+import "../styles/globals.css";
+
+export default function Showcase() {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [playing, setPlaying] = useState(false);
+
+  const toggleMusic = () => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (playing) {
+      audio.pause();
+    } else {
+      audio.play();
+    }
+    setPlaying(!playing);
+  };
+
+  return (
+    <div>
+      <header>
+        <h1>Showcase</h1>
+      </header>
+      <main>
+        <button className="music-toggle" onClick={toggleMusic}>
+          {playing ? "Mute" : "Music"}
+        </button>
+        <audio ref={audioRef} src="/music/theme.mp3" loop />
+        <section className="video-section">
+          <h2>GP-Motor - Bilhandlare i Strängnäs.</h2>
+          <video autoPlay loop muted playsInline src="/videos/gp-motor.mp4" />
+        </section>
+        <section className="video-section">
+          <h2>Olivträdgården - Olivträd av premium kvalité.</h2>
+          <video
+            autoPlay
+            loop
+            muted
+            playsInline
+            src="/videos/olivtradgarden.mp4"
+          />
+        </section>
+        <section className="video-section">
+          <h2>Grekiska Tavernan - Restaurang i Strängnäs hamn.</h2>
+          <video
+            autoPlay
+            loop
+            muted
+            playsInline
+            src="/videos/grekiska-tavernan.mp4"
+          />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/hobbyhosting-frontend/public/music/README.md
+++ b/apps/hobbyhosting-frontend/public/music/README.md
@@ -1,0 +1,1 @@
+Add your background music file here named theme.mp3. The showcase page can toggle playback.

--- a/apps/hobbyhosting-frontend/public/videos/README.md
+++ b/apps/hobbyhosting-frontend/public/videos/README.md
@@ -1,0 +1,5 @@
+Place your MP4 files here for the showcase page. Use the following filenames:
+
+- gp-motor.mp4
+- olivtradgarden.mp4
+- grekiska-tavernan.mp4

--- a/apps/hobbyhosting-frontend/styles/globals.css
+++ b/apps/hobbyhosting-frontend/styles/globals.css
@@ -50,3 +50,55 @@ nav a {
   color: #4f46e5;
   text-decoration: none;
 }
+
+.video-wrapper {
+  position: relative;
+  padding-bottom: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+
+.video-wrapper iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.video-section {
+  position: relative;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  color: #fff;
+}
+
+.video-section h2 {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  z-index: 1;
+  margin: 0;
+}
+
+.video-section video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.music-toggle {
+  position: fixed;
+  left: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  padding: 0.5rem 1rem;
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- create placeholder public directories for music and video uploads
- implement autoplaying video showcase with background music toggle
- style fullscreen video sections and music button
- keep the front page simple without showcase links

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'jose' & 'httpx')*
- `pre-commit` *(not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6839fdf9ffb48332a1595e6548303d51